### PR TITLE
Use 0.4.1 of ThreadingUtilities to stop crashes when !isbits non-array args are used

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ IfElse = "0.1"
 Requires = "1"
 Static = "0.2.4"
 StrideArraysCore = "0.1.2"
-ThreadingUtilities = "0.4"
+ThreadingUtilities = "0.4.1"
 VectorizationBase = "0.18.7,0.19"
 julia = "1.5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CheapThreads"
 uuid = "b630d9fa-e28e-4980-896d-83ce5e2106b2"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -73,7 +73,7 @@ end
             i == nthread && break
         end
         # @show start, ulen
-        f!(map(dereference, argtup), start, ulen)
+        f!(map(dereference, argtup), start+one(UInt), ulen)
         tm = mask(threads)
         tid = 0x00000000
         while true
@@ -139,7 +139,7 @@ end
             start = stop
             i == nthread && break
         end
-        f!(map(dereference, argtup), start, ulen)
+        f!(map(dereference, argtup), start+one(UInt), ulen)
         tid = 0x00000000
         while true
             VectorizationBase.assume(wait_mask ≠ zero(wait_mask))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,12 +34,22 @@ using Test
         end
         x[1,j] = target
     end
+
     function slow_cheap(n, digits)
         x = zeros(8, num_threads())
         batch(slow_task!, (num_threads(), num_threads()), x, digits, n)
         sum(@view(x[1,1:end]))
     end
-    slow_cheap(1000, "9")
+
+    function slow_single_thread(n, digits)
+        target = 0.0
+        for i ∈ 1:n
+            target += occursin(digits, string(i)) ? 0.0 : 1.0 / i
+        end
+        return target
+    end
+    
+    @test slow_cheap(1000, "9") ≈ slow_single_thread(1000,"9")
 end
 
 @testset "!isbits args" begin


### PR DESCRIPTION
Closes #4 