### PR TITLE
revert special handling of NamedTuples in at-batch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CheapThreads"
 uuid = "b630d9fa-e28e-4980-896d-83ce5e2106b2"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -36,7 +36,7 @@ push_tup!(x, ::Type{NamedTuple{S,T}}, t) where {S,T<:Tuple} = push!(x, Expr(:cal
 function add_var!(q, argtup, gcpres, ::Type{T}, argtupname, gcpresname, k) where {T}
     parg_k = Symbol(argtupname, :_, k)
     garg_k = Symbol(gcpresname, :_, k)
-    if (T <: Tuple) || (T <: NamedTuple)
+    if (T <: Tuple) # || (T <: NamedTuple) # NamedTuples do currently not work in all cases, see https://github.com/JuliaSIMD/CheapThreads.jl/issues/20
         push!(q.args, Expr(:(=), parg_k, Expr(:ref, argtupname, k)))
         t = Expr(:tuple)
         for (j,p) ∈ enumerate(_extract_params(T))
@@ -48,7 +48,7 @@ function add_var!(q, argtup, gcpres, ::Type{T}, argtupname, gcpresname, k) where
         push!(argtup.args, parg_k)
         push!(gcpres.args, garg_k)
     end
-end   
+end
 
 @generated function _batch_no_reserve(
     f!::F, threadmask, nthread, torelease, Nr, Nd, ulen, args::Vararg{Any,K}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,7 @@ end
         start_indices[Threads.threadid()] = start
         end_indices[Threads.threadid()] = stop
     end
-    
+
     start_indices = zeros(Int, num_threads())
     end_indices = zeros(Int, num_threads())
 
@@ -168,6 +168,23 @@ end
     update_text!((ts, val), start, stop) = ts.vec[start:stop] .= val
     batch(update_text!, (vec_length, num_threads()), ts, "new_val")
     @test all(ts.vec .== "new_val")
+
+
+    struct Issue20
+        values::Vector{Float64}
+    end
+
+    function issue20!(dest, cache)
+        @batch for i in eachindex(dest)
+            factor = -cache.a.values[i]
+            dest[i] *= factor
+        end
+    end
+
+    dest = ones(20)
+    cache = (; a = Issue20(ones(length(dest))))
+    issue20!(dest, cache)
+    @test all(dest .≈ -1)
 end
 
 @testset "ForwardDiff" begin


### PR DESCRIPTION
This is a (dirty) workaround of the problem reported in #20. I wasn't really able to find a proper fix but would like to use CheapThreads in its current state.